### PR TITLE
Add 'libft' submodule to .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libft"]
+	path = libft
+	url = https://github.com/pfalli/Libft.git


### PR DESCRIPTION
The git submodule called 'libft' has been added to the project correctly. The URL for the repository has been set to https://github.com/pfalli/Libft.git. The commit which the main points to has also been updated